### PR TITLE
yarn lint should also look at .ts files

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vue-tsc && vite build",
     "preview": "vite preview",
     "test": "vitest",
-    "lint": "eslint --fix --ext .js,.vue --ignore-path .gitignore --fix src",
+    "lint": "eslint --fix --ext .ts,.js,.vue --ignore-path .gitignore --fix src",
     "format": "prettier .  --write"
   },
   "dependencies": {


### PR DESCRIPTION
Previously, `yarn lint` only ran on .js and .vue files.  However, we should also run it on standalone typescript files.