### PR TITLE
prefix envvar with VITE_ to make it available to the browser

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 export default {
-    allsearchApiUrl: import.meta.env.ALLSEARCH_API_URL || 'https://allsearch-api-staging.princeton.edu',
+    allsearchApiUrl: import.meta.env.VITE_ALLSEARCH_API_URL || 'https://allsearch-api-staging.princeton.edu',
     honeybadgerApiKey: import.meta.env.VITE_HONEYBADGER_API_KEY,
     honeybadgerEnvironment: import.meta.env.VITE_HONEYBADGER_ENV,
 }


### PR DESCRIPTION
Sibling PR in princeton_ansible: https://github.com/pulibrary/princeton_ansible/pull/4414

Helps with #88 