### PR TITLE
Trays don't expand to fit the whole row height

### DIFF
--- a/src/components/TrayContainer.vue
+++ b/src/components/TrayContainer.vue
@@ -53,5 +53,7 @@ const searchService = new SearchService();
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
+  align-items: flex-start;
+  min-height: 300px;
 }
 </style>


### PR DESCRIPTION
Also adds min-height to the row, to make trays jump around a bit less when the data is loading.

closes #94 