### PR TITLE
Remove eslint from circleci. We are using githook now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,6 @@ jobs:
           command: yarn test
           name: Run yarn tests
       - run:
-          name: Run eslint and prettier
-          command: yarn lint
-      - run:
           name: Check types
           command: yarn exec vue-tsc
   semgrep:


### PR DESCRIPTION
closes #84 

We are using githook to lint files before committing. 