### PR TITLE
Fix duplicate metadata in catalog tray

### DIFF
--- a/src/components/metadata/ArticlesMetadata.vue
+++ b/src/components/metadata/ArticlesMetadata.vue
@@ -1,4 +1,7 @@
 <template>
+  <li v-if="document.creator">
+    <span class="visually-hidden">Creator: </span>{{ document.creator }}
+  </li>
   <li v-if="document.other_fields?.fulltext_available">
     <InlineBadge>Full-text available</InlineBadge>
   </li>

--- a/src/components/metadata/SearchMetadata.vue
+++ b/src/components/metadata/SearchMetadata.vue
@@ -6,24 +6,12 @@
         :icon="getIconType(document.type)"
       ></FormatWithIcon>
     </li>
-    <CatalogMetadata
-      v-if="scope === SearchScope.Catalog"
-      :document="document"
-    ></CatalogMetadata>
-    <ArticlesMetadata
-      v-if="scope === SearchScope.Articles"
-      :document="document"
-    ></ArticlesMetadata>
-    <FindingaidsMetadata
-      v-if="scope === SearchScope.FindingAids"
-      :document="document"
-    ></FindingaidsMetadata>
-    <PulmapsMetadata :document="document"></PulmapsMetadata>
+    <component :is="metadataComponent" :document="document"></component>
   </ul>
 </template>
 
 <script setup lang="ts">
-import { PropType } from 'vue';
+import { type Component, PropType } from 'vue';
 import { SearchResult } from '../../models/SearchResult';
 import { SearchScope } from '../../enums/SearchScope';
 import itemTypeMap from '../../config/ItemTypeMap';
@@ -48,8 +36,25 @@ const props = defineProps({
   }
 });
 
+let metadataComponent: Component;
+
+switch (props.scope) {
+  case SearchScope.Catalog:
+    metadataComponent = CatalogMetadata;
+    break;
+  case SearchScope.Articles:
+    metadataComponent = ArticlesMetadata;
+    break;
+  case SearchScope.FindingAids:
+    metadataComponent = FindingaidsMetadata;
+    break;
+  case SearchScope.PulMap:
+    metadataComponent = PulmapsMetadata;
+    break;
+}
+
 function getIconType(type: string): string {
-  const itemType = itemTypeMap[type as keyof typeof itemTypeMap];
+  const itemType = itemTypeMap[type.toLowerCase() as keyof typeof itemTypeMap];
   return itemType ? itemType : props.defaultIcon;
 }
 </script>

--- a/src/config/ItemTypeMap.ts
+++ b/src/config/ItemTypeMap.ts
@@ -1,6 +1,10 @@
 export default {
-  Book: 'text',
+  audio: 'audio',
+  archives: 'archives',
+  book: 'book',
+  coin: 'coin',
   collection: 'collection',
-  'Journal Article': 'text',
+  ebook: 'book',
+  'journal article': 'text',
   map: 'map'
 };


### PR DESCRIPTION
Currently, the "map" metadata is showing up in every tray

Also, make icon/format matching case-insensitive