### PR TITLE
i60: FAQ tray

### DIFF
--- a/assets/app.css
+++ b/assets/app.css
@@ -55,6 +55,10 @@ body {
   content: '\f639';
 }
 
+.icon-question::before {
+  content: '\f558';
+}
+
 .icon-search::before {
   content: '\e90b';
 }

--- a/src/components/TrayContainer.vue
+++ b/src/components/TrayContainer.vue
@@ -3,6 +3,7 @@
     <h1>Coming soon</h1>
     <SearchBar></SearchBar>
     <div class="row">
+      <!-- row 1 -->
       <SearchTray
         :scope="SearchScope.Catalog"
         :results-promise="searchService.results(SearchScope.Catalog, query)"
@@ -15,6 +16,7 @@
       ></SearchTray>
     </div>
     <div class="row">
+      <!-- row 2 -->
       <SearchTray
         :scope="SearchScope.FindingAids"
         :results-promise="searchService.results(SearchScope.FindingAids, query)"
@@ -27,6 +29,7 @@
       ></SearchTray>
     </div>
     <div class="row">
+      <!-- row 3 -->
       <SearchTray
         :scope="SearchScope.PulMap"
         :results-promise="searchService.results(SearchScope.PulMap, query)"
@@ -39,11 +42,21 @@
       ></SearchTray>
     </div>
     <div class="row"></div>
+    <!-- row 4 -->
     <div class="row">
+      <!-- row 5 -->
       <SearchTray
         :scope="SearchScope.LibGuides"
         :results-promise="searchService.results(SearchScope.LibGuides, query)"
         default-icon="compass"
+      ></SearchTray>
+    </div>
+    <div class="row">
+      <!-- row 6 -->
+      <SearchTray
+        :scope="SearchScope.LibAnswers"
+        :results-promise="searchService.results(SearchScope.LibAnswers, query)"
+        default-icon="question"
       ></SearchTray>
     </div>
   </div>

--- a/src/components/metadata/SearchMetadata.vue
+++ b/src/components/metadata/SearchMetadata.vue
@@ -7,8 +7,10 @@
       ></FormatWithIcon>
     </li>
     <li v-for="field in basicFieldList" :key="field">
-      <span class="visually-hidden">{{ field }}: </span
-      >{{ document[field as keyof SearchResult] }}
+      <div v-if="document[field as keyof SearchResult] && field !== 'format'">
+        <span class="visually-hidden">{{ field }}: </span
+        >{{ document[field as keyof SearchResult] }}
+      </div>
     </li>
     <component
       :is="metadataComponent"

--- a/src/config/ScopeFieldsMap.ts
+++ b/src/config/ScopeFieldsMap.ts
@@ -8,7 +8,7 @@ const map: { [key in SearchScope]: string[] } = {
   database: [],
   dpul: ['format', 'creator'],
   findingaids: ['format'],
-  libanswers: [],
+  libanswers: ['creator'],
   libguides: ['description'],
   pulmap: ['format', 'creator', 'publisher']
 };

--- a/src/config/ScopeTitleMap.ts
+++ b/src/config/ScopeTitleMap.ts
@@ -4,6 +4,7 @@ export default {
   artmuseum: 'Art Museum Collections',
   dpul: 'Digital PUL',
   findingaids: 'Library Archives',
+  libanswers: 'Library FAQ',
   libguides: 'Library Guides',
   pulmap: 'Maps and Geographic Data'
 };

--- a/src/config/ScopeUrlMap.ts
+++ b/src/config/ScopeUrlMap.ts
@@ -4,6 +4,7 @@ export default {
   artmuseum: 'https://artmuseum.princeton.edu/search/collections',
   dpul: 'https://dpul.princeton.edu/',
   findingaids: 'https://findingaids.princeton.edu',
+  libanswers: 'https://faq.library.princeton.edu/search',
   libguides: 'https://libguides.princeton.edu',
   pulmap: 'https://maps.princeton.edu'
 };


### PR DESCRIPTION
closes #60 

Also includes a fix to an issue I noticed with VoiceOver, where empty metadata fields are still included in visually hidden text