### PR TITLE
Add Content Security Policy

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval'; connect-src 'self' localhost:* https://allsearch-api.princeton.edu https://allsearch-api-staging.princeton.edu; font-src 'self'; base-uri 'none';img-src 'self';">
     <title>Princeton University Library</title>
   </head>
   <body>


### PR DESCRIPTION
Using a <meta> tag rather than an HTTP header,
since this application doesn't have an application server.