### PR TITLE
Remove focus from tray title

### DIFF
--- a/src/components/TrayTitle.vue
+++ b/src/components/TrayTitle.vue
@@ -1,5 +1,5 @@
 <template>
-  <h2 :id="headingId" tabindex="0">
+  <h2 :id="headingId">
     <span v-if="props.icon" :class="iconClass" aria-hidden="true"></span>
     {{ props.heading }}
   </h2>


### PR DESCRIPTION
Tray title is not a link. It doesn't need to have focus.