### PR TITLE
Reduce mobile layout shift

### DIFF
--- a/src/components/TrayLayout.vue
+++ b/src/components/TrayLayout.vue
@@ -24,5 +24,6 @@ section {
   width: max(calc(30vw - 30px), 360px);
   overflow-wrap: anywhere;
   flex-grow: 1;
+  min-height: 300px;
 }
 </style>


### PR DESCRIPTION
Previously, in mobile screens, the full catalog and article trays would display prior to the data being loaded.  After the data is loaded, the catalog tray is almost always so big that it pushes the article tray below the fold in mobile views.  This layout shift could be annoying to users with slow connections who see articles momentarily, then it disappears.

Setting a reasonable min-height for each tray makes this layout shift less drastic, and brings the mobile CLS (as measured locally with Lighthouse using the search term "music") from .36 to .143.

helps with #155 