### PR TITLE
Reduce cumulative layout shift on desktop sizes

### DIFF
--- a/src/components/BestBetsTray.test.ts
+++ b/src/components/BestBetsTray.test.ts
@@ -62,9 +62,9 @@ describe('BestBetsTray component', () => {
         }
       });
     });
-    test('it displays no content', async () => {
+    test('it displays a placeholder', async () => {
       await flushPromises();
-      expect(wrapper.html()).toEqual('<!--v-if-->');
+      expect(wrapper.html()).toEqual('<div class="placeholder"></div>');
     });
     test('it emits an event with 0 results and the dom ID', async () => {
       await flushPromises();

--- a/src/components/BestBetsTray.vue
+++ b/src/components/BestBetsTray.vue
@@ -28,6 +28,7 @@
       ></MoreResults>
     </template>
   </TrayLayout>
+  <div v-else class="placeholder"></div>
 </template>
 
 <script setup lang="ts">

--- a/src/components/TrayContainer.vue
+++ b/src/components/TrayContainer.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="query">
     <div class="header__secondary">
-      <nav aria-label="search tools">
+      <nav aria-label="search tools" class="search-tools">
         <SearchBar></SearchBar>
         <JumpToSection :trays-to-link="completedTrays"></JumpToSection>
       </nav>
@@ -17,7 +17,9 @@
             @search-data-loaded="handleDataLoaded"
           >
           </component>
-          <div v-else><!-- no tray is configured for this cell --></div>
+          <div v-else class="placeholder">
+            <!-- no tray is configured for this cell -->
+          </div>
         </template>
       </div>
     </div>
@@ -56,6 +58,8 @@ function markTrayAsCompleted(summary: SearchDataLoadSummary) {
 function handleDataLoaded(summary: SearchDataLoadSummary) {
   if (summary.scope === SearchScope.BestBets && summary.results === 0) {
     trayOrder.removeBestBets();
+
+    // Reload the rows property, now that best bets has been removed
     rows.value = trayOrder.asRows;
   } else {
     markTrayAsCompleted(summary);
@@ -67,7 +71,7 @@ function trayComponent(scope: SearchScope): Component {
 }
 </script>
 
-<style scoped>
+<style>
 .tray-grid {
   display: flex;
   justify-content: center;
@@ -84,7 +88,14 @@ function trayComponent(scope: SearchScope): Component {
   gap: 2vw;
 }
 
-nav {
+.row > section,
+.row > div.placeholder {
+  width: max(calc(30vw - 30px), 360px);
+  overflow-wrap: anywhere;
+  flex-grow: 1;
+}
+
+nav.search-tools {
   display: flex;
   justify-content: space-between;
   padding: 0 30px;

--- a/src/components/TrayLayout.vue
+++ b/src/components/TrayLayout.vue
@@ -21,9 +21,6 @@ section {
   padding: 2px 15px 18px;
   border: 1px var(--gray) solid;
   margin-top: 10px;
-  width: max(calc(30vw - 30px), 360px);
-  overflow-wrap: anywhere;
-  flex-grow: 1;
   min-height: 300px;
 }
 </style>


### PR DESCRIPTION
Previously, while the Best Bet tray was deciding whether or not to display, the first row showed two large columns, rather than three medium-sized ones.  This led to layout shift, once the third column shows up.

This brings the desktop CLS from .3 to .091

closes #155 