### PR TITLE
Display status from other_fields in the API response

### DIFF
--- a/assets/app.css
+++ b/assets/app.css
@@ -172,14 +172,16 @@ h3 {
   --orange-40: #F58025;
   --orange-20: #FAE3CC;
   --orange-10: #FCF1E5;
+  --red: #D12A2F;
+  --green: #1A8648;
   --architecture: #C3D600;
   --engineering: #3B7CCA;
   --lewis: #915BAF;
   --mendel: #DA1884;
   --special-collections: #000;
-  --east-asian: #1A8648;
+  --east-asian: var(--green);
   --firestone: #EE7421;
-  --marquand: #D12A2F;
+  --marquand: var(--red);
   --mudd: #F2A900;
   --stokes: #C24D01;
 }

--- a/src/components/InlineBadge.vue
+++ b/src/components/InlineBadge.vue
@@ -1,15 +1,37 @@
 <template>
-  <span class="badge"><slot></slot></span>
+  <span :class="badge_class"><slot></slot></span>
 </template>
+<script setup lang="ts">
+const props = defineProps({
+  color: {
+    type: String,
+    default: 'green'
+  }
+});
+const badge_class = `badge badge-${props.color}`;
+</script>
 <style>
 .badge {
-  background: #c3ed79;
-  color: #3e5b0c;
   padding: 4px;
   letter-spacing: 0.32px;
   margin: 0.25rem 0.25rem 0.25rem 0;
   border-radius: 3px;
   border: 1px solid var(--gray-50);
   display: inline-block;
+}
+
+.badge-green {
+  background: var(--green);
+  color: var(--gray-10);
+}
+
+.badge-red {
+  background: var(--red);
+  color: var(--gray-10);
+}
+
+.badge-gray {
+  background: var(--gray-10);
+  color: var(--gray-90);
 }
 </style>

--- a/src/components/PhysicalHoldings.test.ts
+++ b/src/components/PhysicalHoldings.test.ts
@@ -75,4 +75,20 @@ describe('PhysicalHoldings component', () => {
     expect(wrapper.text()).toMatch(/Location:\s*ReCAP/);
     expect(wrapper.text()).toMatch(/Location:\s*Firestone/);
   });
+  test('it shows a green status badge if other_fields has a status to display', () => {
+    wrapper = mount(PhysicalHoldings, {
+      props: {
+        document: {
+          title: '',
+          url: '',
+          id: '',
+          other_fields: {
+            first_library: 'Lewis',
+            first_status: 'Available'
+          }
+        }
+      }
+    });
+    expect(wrapper.find('.badge-green').text()).toMatch(/Available/);
+  });
 });

--- a/src/components/PhysicalHoldings.vue
+++ b/src/components/PhysicalHoldings.vue
@@ -1,18 +1,23 @@
 <template>
   <ul>
-    <li v-for="holding of holdingsDisplays" v-bind:key="holding">
-      <span v-if="holding" class="visually-hidden">Location: </span>
-      {{ holding }}
+    <li v-for="holding of holdings" v-bind:key="holding.call_number">
+      <InlineBadge v-if="holding.status" :color="holding.statusColor()">{{
+        holding.status
+      }}</InlineBadge>
+      <span class="visually-hidden">Location: </span>
+      {{ holding.label() }}
     </li>
   </ul>
 </template>
 <script setup lang="ts">
+import { PhysicalHolding } from '../models/PhysicalHolding';
 import { SearchResult } from '../models/SearchResult';
 import { HoldingsService } from '../services/HoldingsService';
+import InlineBadge from './InlineBadge.vue';
 const props = defineProps<{
   document: SearchResult;
 }>();
-const holdingsDisplays: string[] = HoldingsService.extractHoldingsStatements(
+const holdings: PhysicalHolding[] = HoldingsService.extractHoldingsArray(
   props.document
 );
 </script>

--- a/src/models/PhysicalHolding.test.ts
+++ b/src/models/PhysicalHolding.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { PhysicalHolding } from './PhysicalHolding';
+
+describe('PhysicalHolding', () => {
+  describe('statusColor()', () => {
+    it('returns green when available', () => {
+      const holding = new PhysicalHolding('Marquand', 'ABC 123', 'Available');
+      expect(holding.statusColor()).toEqual('green');
+    });
+    it('returns red when unavailable', () => {
+      const holding = new PhysicalHolding('Marquand', 'ABC 123', 'Unavailable');
+      expect(holding.statusColor()).toEqual('red');
+    });
+    it('returns gray when there is no status', () => {
+      const holding = new PhysicalHolding('Marquand');
+      expect(holding.statusColor()).toEqual('gray');
+    });
+  });
+});

--- a/src/models/PhysicalHolding.ts
+++ b/src/models/PhysicalHolding.ts
@@ -1,0 +1,27 @@
+export class PhysicalHolding {
+  library: string;
+  call_number?: string;
+  status?: string;
+  constructor(library: string, call_number?: string, status?: string) {
+    this.library = library;
+    this.call_number = call_number;
+    this.status = status;
+  }
+  label() {
+    if (this.library && this.call_number) {
+      return `${this.library} » ${this.call_number}`;
+    } else if (this.library) {
+      return this.library;
+    }
+  }
+  statusColor(): string {
+    switch (this.status) {
+      case 'Available':
+        return 'green';
+      case 'Unavailable':
+        return 'red';
+      default:
+        return 'gray';
+    }
+  }
+}

--- a/src/services/HoldingsService.test.ts
+++ b/src/services/HoldingsService.test.ts
@@ -3,8 +3,8 @@ import { Result } from '../interfaces/Result';
 import { HoldingsService } from './HoldingsService';
 
 describe('HoldingsService', () => {
-  describe('extractHoldingsStatements()', () => {
-    it('can extract a single holdings statement', () => {
+  describe('extractHoldingsArray()', () => {
+    it('can extract a holding', () => {
       const document: Result = {
         title: '',
         url: '',
@@ -14,8 +14,8 @@ describe('HoldingsService', () => {
           first_call_number: 'DU110 .G738 1947'
         }
       };
-      const expected = ['ReCAP » DU110 .G738 1947'];
-      expect(HoldingsService.extractHoldingsStatements(document)).toEqual(
+      const expected = 'ReCAP » DU110 .G738 1947';
+      expect(HoldingsService.extractHoldingsArray(document)[0].label()).toEqual(
         expected
       );
     });

--- a/src/services/HoldingsService.ts
+++ b/src/services/HoldingsService.ts
@@ -1,20 +1,25 @@
 import { Result } from '../interfaces/Result';
+import { PhysicalHolding } from '../models/PhysicalHolding';
 
 export class HoldingsService {
-  static extractHoldingsStatements(document: Result): string[] {
+  // Take holdings information from the other_fields in the Result
+  // document.  Only add an array element if we have enough
+  // data that would be useful for the user.
+  static extractHoldingsArray(document: Result): PhysicalHolding[] {
     const order = ['first', 'second'];
     return order.reduce((holdingsDisplays, number) => {
       const other_fields = document?.other_fields;
       if (other_fields) {
         const library = other_fields[`${number}_library`];
         const call_number = other_fields[`${number}_call_number`];
-        if (library && call_number) {
-          holdingsDisplays.push(`${library} » ${call_number}`);
-        } else if (library) {
-          holdingsDisplays.push(library);
+        const status = other_fields[`${number}_status`];
+        if (library) {
+          holdingsDisplays.push(
+            new PhysicalHolding(library, call_number, status)
+          );
         }
       }
       return holdingsDisplays;
-    }, [] as string[]);
+    }, [] as PhysicalHolding[]);
   }
 }


### PR DESCRIPTION
This will display a status badge for all catalog items with physical holdings except Recap items, which will come in a separate PR.

Helps with #166 