### PR TITLE
Update node version to 18.18.0 in circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       - checkout
       - node/install:
           install-yarn: true
-          node-version: '18.12'
+          node-version: '18.18.0'
       - node/install-packages:
           pkg-manager: yarn
       - run:
@@ -37,7 +37,7 @@ jobs:
       - ruby/install-deps
       - node/install:
           install-yarn: true
-          node-version: '18.12'
+          node-version: '18.18.0'
       - node/install-packages:
           pkg-manager: yarn
       - ruby/rspec-test
@@ -49,7 +49,7 @@ jobs:
       - checkout
       - node/install:
           install-yarn: true
-          node-version: '18.12'
+          node-version: '18.18.0'
       - node/install-packages:
           pkg-manager: yarn
       - run:


### PR DESCRIPTION
When we added Dastardly in [this commit](https://github.com/pulibrary/allsearch_frontend/pull/178/files) the node version changed to 18.12