### PR TITLE
Refactor: CatalogMetadata only accepts the data it needs for display

### DIFF
--- a/src/components/PhysicalHoldings.test.ts
+++ b/src/components/PhysicalHoldings.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeAll } from 'vitest';
 import { VueWrapper, mount } from '@vue/test-utils';
 import PhysicalHoldings from './PhysicalHoldings.vue';
+import { PhysicalHolding } from '../models/PhysicalHolding';
 
 let wrapper: VueWrapper;
 
@@ -9,15 +10,7 @@ describe('PhysicalHoldings component', () => {
     beforeAll(() => {
       wrapper = mount(PhysicalHoldings, {
         props: {
-          document: {
-            title: '',
-            url: '',
-            id: '',
-            other_fields: {
-              first_library: 'ReCAP',
-              first_call_number: 'DU110 .G738 1947'
-            }
-          }
+          holdings: [new PhysicalHolding('ReCAP', 'DU110 .G738 1947')]
         }
       });
     });
@@ -31,29 +24,15 @@ describe('PhysicalHoldings component', () => {
   test('it shows only the library if no call number is available', async () => {
     wrapper = mount(PhysicalHoldings, {
       props: {
-        document: {
-          title: '',
-          url: '',
-          id: '',
-          other_fields: {
-            first_library: 'ReCAP'
-          }
-        }
+        holdings: [new PhysicalHolding('ReCAP')]
       }
     });
     expect(wrapper.text()).toMatch(/Location:\s*ReCAP/);
   });
-  test('it shows nothing if the library is not available', async () => {
+  test('it shows nothing if no holdings are available', async () => {
     wrapper = mount(PhysicalHoldings, {
       props: {
-        document: {
-          title: '',
-          url: '',
-          id: '',
-          other_fields: {
-            first_call_number: 'DU110 .G738 1947'
-          }
-        }
+        holdings: []
       }
     });
     expect(wrapper.text()).toEqual('');
@@ -61,15 +40,10 @@ describe('PhysicalHoldings component', () => {
   test('it shows a second holding if available', () => {
     wrapper = mount(PhysicalHoldings, {
       props: {
-        document: {
-          title: '',
-          url: '',
-          id: '',
-          other_fields: {
-            first_library: 'ReCAP',
-            second_library: 'Firestone'
-          }
-        }
+        holdings: [
+          new PhysicalHolding('ReCAP'),
+          new PhysicalHolding('Firestone')
+        ]
       }
     });
     expect(wrapper.text()).toMatch(/Location:\s*ReCAP/);
@@ -78,15 +52,7 @@ describe('PhysicalHoldings component', () => {
   test('it shows a green status badge if other_fields has a status to display', () => {
     wrapper = mount(PhysicalHoldings, {
       props: {
-        document: {
-          title: '',
-          url: '',
-          id: '',
-          other_fields: {
-            first_library: 'Lewis',
-            first_status: 'Available'
-          }
-        }
+        holdings: [new PhysicalHolding('Stokes', undefined, 'Available')]
       }
     });
     expect(wrapper.find('.badge-green').text()).toMatch(/Available/);

--- a/src/components/PhysicalHoldings.vue
+++ b/src/components/PhysicalHoldings.vue
@@ -1,6 +1,6 @@
 <template>
   <ul>
-    <li v-for="holding of holdings" v-bind:key="holding.call_number">
+    <li v-for="holding of props.holdings" v-bind:key="holding.call_number">
       <InlineBadge v-if="holding.status" :color="holding.statusColor()">{{
         holding.status
       }}</InlineBadge>
@@ -11,13 +11,8 @@
 </template>
 <script setup lang="ts">
 import { PhysicalHolding } from '../models/PhysicalHolding';
-import { SearchResult } from '../models/SearchResult';
-import { HoldingsService } from '../services/HoldingsService';
 import InlineBadge from './InlineBadge.vue';
 const props = defineProps<{
-  document: SearchResult;
+  holdings: PhysicalHolding[];
 }>();
-const holdings: PhysicalHolding[] = HoldingsService.extractHoldingsArray(
-  props.document
-);
 </script>

--- a/src/components/SearchTray.vue
+++ b/src/components/SearchTray.vue
@@ -33,7 +33,8 @@
               ></ArtMuseumMetadata>
               <CatalogMetadata
                 v-if="props.scope == SearchScope.Catalog"
-                :document="document"
+                :url="document?.other_fields?.resource_url"
+                :holdings="HoldingsService.extractHoldingsArray(document)"
               ></CatalogMetadata>
               <DpulMetadata
                 v-if="props.scope == SearchScope.Dpul"
@@ -96,6 +97,7 @@ import LibraryStaffMetadata from './metadata/LibraryStaffMetadata.vue';
 import DpulMetadata from './metadata/DpulMetadata.vue';
 import WebsiteMetadata from './metadata/WebsiteMetadata.vue';
 import ScopeFieldsMap from '../config/ScopeFieldsMap';
+import { HoldingsService } from '../services/HoldingsService';
 
 const props = defineProps({
   scope: {

--- a/src/components/metadata/CatalogMetadata.test.ts
+++ b/src/components/metadata/CatalogMetadata.test.ts
@@ -1,14 +1,15 @@
 import { beforeEach, describe, expect, test } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import CatalogMetadata from './CatalogMetadata.vue';
-import CatalogMetadataFixtures from '../../fixtures/CatalogMetadataFixtures';
+import { PhysicalHolding } from '../../models/PhysicalHolding';
 
 describe('CatalogMetadata', () => {
   let wrapper: VueWrapper;
   beforeEach(() => {
     wrapper = mount(CatalogMetadata, {
       props: {
-        document: CatalogMetadataFixtures.testResult
+        holdings: [new PhysicalHolding('Firestone', 'ABC 123', 'Available')],
+        url: 'https://na05.alma.exlibrisgroup.com/view/uresolver/01PRI_INST/openurl?u.ignore_date_coverage=true&portfolio_pid=53763462940006421&Force_direct=true'
       }
     });
   });

--- a/src/components/metadata/CatalogMetadata.vue
+++ b/src/components/metadata/CatalogMetadata.vue
@@ -1,22 +1,22 @@
 <template>
-  <li v-if="document.other_fields?.first_library" class="access-info">
-    <PhysicalHoldings :document="document"></PhysicalHoldings>
+  <li v-if="holdings.length" class="access-info">
+    <PhysicalHoldings :holdings="holdings"></PhysicalHoldings>
   </li>
-  <li v-if="document.other_fields?.resource_url" class="access-info">
-    <OnlineContent :url="document.other_fields.resource_url"></OnlineContent>
+  <li v-if="url" class="access-info">
+    <OnlineContent :url="url"></OnlineContent>
   </li>
 </template>
 
 <script setup lang="ts">
-import { PropType } from 'vue';
-import { SearchResult } from '../../models/SearchResult';
-
 import OnlineContent from '../OnlineContent.vue';
 import PhysicalHoldings from '../PhysicalHoldings.vue';
+import { PhysicalHolding } from '../../models/PhysicalHolding';
+import { PropType } from 'vue';
 
 defineProps({
-  document: {
-    type: Object as PropType<SearchResult>,
+  url: String,
+  holdings: {
+    type: Array as PropType<PhysicalHolding[]>,
     required: true
   }
 });


### PR DESCRIPTION
Rather than parsing the entire search result document

Related to #166 