### PR TITLE
Allow Adobe font in the Content Security Policy

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval'; connect-src 'self' localhost:* https://allsearch-api.princeton.edu https://allsearch-api-staging.princeton.edu; font-src 'self'; base-uri 'none';img-src 'self';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'self' 'unsafe-inline' https://use.typekit.net https://p.typekit.net; script-src 'self' 'unsafe-eval'; connect-src 'self' localhost:* https://allsearch-api.princeton.edu https://allsearch-api-staging.princeton.edu; font-src 'self' https://use.typekit.net; base-uri 'none';img-src 'self';">
     <title>Princeton University Library</title>
     <link rel="preconnect" href="https://allsearch-api.princeton.edu/" crossorigin="anonymous">
   </head>


### PR DESCRIPTION
Currently it is being blocked, according to my firefox console:

```
Content-Security-Policy: The page’s settings blocked the loading of a resource at https://use.typekit.net/xbi8ees.css (“style-src”).
```