### PR TITLE
Don't override alma holding status labels with SCSB API results

### DIFF
--- a/src/models/RecordHoldingsMap.ts
+++ b/src/models/RecordHoldingsMap.ts
@@ -22,7 +22,7 @@ export class RecordHoldingsMap {
   updateScsbAvailability(): Promise<boolean> {
     const bibdata = new BibdataService();
     return bibdata
-      .scsbAvailability(this.barcodes())
+      .scsbAvailability(this.scsbBarcodes())
       .then(results => {
         Object.keys(results).forEach(barcode => {
           Object.keys(this.mapping).forEach(recordId => {
@@ -47,9 +47,12 @@ export class RecordHoldingsMap {
       });
   }
 
-  barcodes(): string[] {
+  scsbBarcodes(): string[] {
     return Object.keys(this.mapping).reduce((barcodeList, documentId) => {
-      return barcodeList.concat(this.barcodesForDocumentId(documentId));
+      if (documentId.startsWith('SCSB-')) {
+        return barcodeList.concat(this.barcodesForDocumentId(documentId));
+      }
+      return barcodeList;
     }, [] as string[]);
   }
 


### PR DESCRIPTION
Currently, if you go to https://allsearch.princeton.edu/?q=robot, the first two results (both from Alma), briefly show the correct status ("Available"), but then are overwritten by an incorrect status ("Unavailable"), which comes from the SCSB response.

This PR fixes this issue by removing the Alma barcodes from the SCSB request, so those barcodes no longer appear in the SCSB response, and the status for alma holdings is not overwritten.