### PR TITLE
Always display correct colors for status badges

### DIFF
--- a/src/components/InlineBadge.vue
+++ b/src/components/InlineBadge.vue
@@ -2,13 +2,14 @@
   <span :class="badge_class"><slot></slot></span>
 </template>
 <script setup lang="ts">
+import { computed } from 'vue';
 const props = defineProps({
   color: {
     type: String,
     default: 'green'
   }
 });
-const badge_class = `badge badge-${props.color}`;
+const badge_class = computed(() => `badge badge-${props.color}`);
 </script>
 <style>
 .badge {

--- a/src/components/PhysicalHoldings.test.ts
+++ b/src/components/PhysicalHoldings.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, beforeAll } from 'vitest';
 import { VueWrapper, mount } from '@vue/test-utils';
 import PhysicalHoldings from './PhysicalHoldings.vue';
 import { PhysicalHolding } from '../models/PhysicalHolding';
+import { nextTick } from 'vue';
 
 let wrapper: VueWrapper;
 
@@ -55,6 +56,19 @@ describe('PhysicalHoldings component', () => {
         holdings: [new PhysicalHolding('Stokes', undefined, 'Available')]
       }
     });
+    expect(wrapper.find('.badge-green').text()).toMatch(/Available/);
+  });
+  test('it updates the color of the badge when the status changes', async () => {
+    const holding = new PhysicalHolding('ReCaP', undefined, 'Loading...');
+    wrapper = mount(PhysicalHoldings, {
+      props: {
+        holdings: [holding]
+      }
+    });
+    expect(wrapper.find('.badge-gray').text()).toMatch(/Loading.../);
+    holding.status = 'Available';
+    wrapper.setProps({ holdings: [holding] });
+    await nextTick();
     expect(wrapper.find('.badge-green').text()).toMatch(/Available/);
   });
 });


### PR DESCRIPTION
previously, when a status updated, the badge color did not also change, since the color was a const computed once when the component was created. Let's use a Vue computed property instead, so that the value can change as the holding status changes.

part of #166 