### PR TITLE
Accessibility improvements for status badges

### DIFF
--- a/src/components/InlineBadge.vue
+++ b/src/components/InlineBadge.vue
@@ -22,7 +22,7 @@ const badge_class = `badge badge-${props.color}`;
 
 .badge-green {
   background: var(--green);
-  color: var(--gray-10);
+  color: var(--white);
 }
 
 .badge-red {

--- a/src/components/PhysicalHoldings.vue
+++ b/src/components/PhysicalHoldings.vue
@@ -1,13 +1,11 @@
 <template>
-  <ul>
-    <li v-for="holding of props.holdings" v-bind:key="holding.call_number">
-      <InlineBadge v-if="holding.status" :color="holding.statusColor()">{{
-        holding.status
-      }}</InlineBadge>
-      <span class="visually-hidden">Location: </span>
-      {{ holding.label() }}
-    </li>
-  </ul>
+  <li v-for="holding of props.holdings" v-bind:key="holding.call_number">
+    <InlineBadge v-if="holding.status" :color="holding.statusColor()">{{
+      holding.status
+    }}</InlineBadge>
+    <span class="visually-hidden">Location: </span>
+    {{ holding.label() }}
+  </li>
 </template>
 <script setup lang="ts">
 import { PhysicalHolding } from '../models/PhysicalHolding';


### PR DESCRIPTION
* Adding status badges as a subsidiary list adds extra structure and verbosity needlessly.  Just add them to the main list
* The Available badge had insufficient contrast.

part of #166 