### PR TITLE
Add honeybadger to content security policy connect-src

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'self' 'unsafe-inline' https://use.typekit.net https://p.typekit.net; script-src 'self' 'unsafe-eval'; connect-src 'self' localhost:* https://allsearch-api.princeton.edu https://allsearch-api-staging.princeton.edu https://bibdata.princeton.edu https://bibdata-staging.princeton.edu; font-src 'self' https://use.typekit.net; base-uri 'none';img-src 'self';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'self' 'unsafe-inline' https://use.typekit.net https://p.typekit.net; script-src 'self' 'unsafe-eval'; connect-src 'self' localhost:* https://allsearch-api.princeton.edu https://allsearch-api-staging.princeton.edu https://bibdata.princeton.edu https://bibdata-staging.princeton.edu https://api.honeybadger.io; font-src 'self' https://use.typekit.net; base-uri 'none';img-src 'self';">
     <title>Princeton University Library</title>
     <link rel="preconnect" href="https://allsearch-api.princeton.edu/" crossorigin="anonymous">
   </head>


### PR DESCRIPTION
Closes #189

Note that you can also [report content-security-policy errors to Honeybadger](https://docs.honeybadger.io/guides/errors/#content-security-policy-reports), but they say it can be noisy, so it's good to have it use a different Honeybadger project.
