### PR TITLE
Catch axios promise rejections (caused by non-200 HTTP responses from the API)

### DIFF
--- a/src/services/SearchService.test.ts
+++ b/src/services/SearchService.test.ts
@@ -1,13 +1,15 @@
 import { Axios } from 'axios';
-import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { describe, test, expect, vi, beforeEach, MockInstance } from 'vitest';
 import { SearchService } from './SearchService';
 import { SearchScope } from '../enums/SearchScope';
 import SearchServiceFixtures from '../fixtures/SearchServiceFixtures';
 
+let mock: MockInstance;
+
 describe('SearchService', () => {
   describe('catalogResults()', () => {
     beforeEach(() => {
-      const mock = vi.spyOn(Axios.prototype, 'get');
+      mock = vi.spyOn(Axios.prototype, 'get');
       mock.mockResolvedValue({
         data: SearchServiceFixtures.results
       });
@@ -26,8 +28,20 @@ describe('SearchService', () => {
     test('it has three results', async () => {
       const service = new SearchService();
       const results = await service.results(SearchScope.Catalog, 'walrus');
-      console.log(results);
       expect(results.records.length).toEqual(3);
+    });
+    describe('when the HTTP request promise is rejected', () => {
+      beforeEach(() => {
+        mock.mockRejectedValue(new Error('Axios error'));
+      });
+      test('it has zero results', async () => {
+        const service = new SearchService();
+        const results = await service.results(
+          SearchScope.Catalog,
+          'this search does not work'
+        );
+        expect(results.records.length).toEqual(0);
+      });
     });
   });
 });

--- a/src/services/SearchService.ts
+++ b/src/services/SearchService.ts
@@ -19,6 +19,7 @@ export class SearchService {
   public results(service: string, query: string): Promise<Results> {
     return this.client
       .get<Results>(`/search/${service}?query=${query}`)
-      .then(res => plainToInstance(SearchResults, res.data));
+      .then(res => plainToInstance(SearchResults, res.data))
+      .catch(() => new SearchResults(0, '', []));
   }
 }


### PR DESCRIPTION
closes #190 