### PR TITLE
Don't check bibdata for SCSB availability unless there are SCSB holdings

### DIFF
--- a/src/models/RecordHoldingsMap.ts
+++ b/src/models/RecordHoldingsMap.ts
@@ -20,6 +20,11 @@ export class RecordHoldingsMap {
   }
 
   updateScsbAvailability(): Promise<boolean> {
+    if (this.scsbBarcodes().length === 0) {
+      // No need to continue if there are no SCSB
+      // holdings to check
+      return Promise.resolve(true);
+    }
     const bibdata = new BibdataService();
     return bibdata
       .scsbAvailability(this.scsbBarcodes())


### PR DESCRIPTION
Bibdata was returning 404 errors for requests to the SCSB availability API that didn't contain any SCSB barcodes.  This manifested as a CORS error in the browser console, since the 404 from the server didn't contain the CORS headers.

closes #234 