### PR TITLE
Add H1 to search results page

### DIFF
--- a/src/components/TrayContainer.test.ts
+++ b/src/components/TrayContainer.test.ts
@@ -1,0 +1,25 @@
+import { describe, test, expect } from 'vitest';
+import TrayContainer from './TrayContainer.vue';
+import { mount } from '@vue/test-utils';
+
+describe('TrayContainer component', () => {
+  describe('when there is no search query', () => {
+    test('it has a visible heading', () => {
+      const wrapper = mount(TrayContainer);
+      expect(wrapper.find('h1').text()).toEqual(
+        'Search Princeton University Library Resources'
+      );
+      expect(wrapper.find('h1').classes()).not.toContain('visually-hidden');
+    });
+  });
+  describe('when there is a search query', () => {
+    test('it has a visually hidden heading', () => {
+      Object.defineProperty(window, 'location', {
+        value: new URL('https://allsearch.princeton.edu?q=robots')
+      });
+      const wrapper = mount(TrayContainer);
+      expect(wrapper.find('h1').text()).toEqual('Search results');
+      expect(wrapper.find('h1').classes()).toContain('visually-hidden');
+    });
+  });
+});

--- a/src/components/TrayContainer.vue
+++ b/src/components/TrayContainer.vue
@@ -6,6 +6,7 @@
         <JumpToSection :trays-to-link="traysToLink"></JumpToSection>
       </nav>
     </div>
+    <h1 class="visually-hidden">Search results</h1>
     <div class="best-bets">
       <BestBetsTray :results-promise="searchService.results('best-bet', query)">
       </BestBetsTray>


### PR DESCRIPTION
Currently, we jump directly to H2 headings.  This PR adds a visually hidden H1 heading at the top of the search results.