### PR TITLE
Update tray grid to use flex and not arrays per column/row

### DIFF
--- a/src/components/BestBetsTray.vue
+++ b/src/components/BestBetsTray.vue
@@ -63,4 +63,9 @@ populateResults();
 .document {
   list-style-type: none;
 }
+
+.best-bets > section {
+  padding: 10px;
+  background-color: #efefef;
+}
 </style>

--- a/src/components/MoreResults.vue
+++ b/src/components/MoreResults.vue
@@ -28,23 +28,19 @@ const props = defineProps({
 
 a.more-link {
   color: var(--black);
-  text-decoration: none;
+  font-weight: bold;
   padding: 14px 24px;
   margin: 12px 7px auto;
-  border: 2px var(--black) solid;
-  border-radius: 5px;
   max-width: 100%;
+  text-decoration: underline;
+  text-underline-offset: 4px;
+  text-align: right;
 }
 
 a.more-link:focus,
 a.more-link:hover {
-  text-decoration: none;
-  color: var(--black);
-  background-color: var(--orange-50);
-}
-
-a.more-link {
-  text-decoration: underline;
+  color: var(--orange-50);
+  text-underline-offset: 4px;
 }
 
 a.more-link .icon-right {

--- a/src/components/SearchTray.vue
+++ b/src/components/SearchTray.vue
@@ -179,23 +179,28 @@ populateResults();
 <style>
 li.document h3 {
   display: inline;
-  text-underline-offset: 5px;
 }
 
 li.document h3 a {
+  line-height: 2rem;
   text-decoration-thickness: 1px;
-  text-decoration-color: var(--gray-50);
+  text-decoration-color: var(--gray-90);
+  text-underline-offset: 5px;
 }
 
 li.document h3 a:focus {
   outline: none;
-  border: 3px solid orange;
+  border: 3px solid var(--orange-50);
   text-decoration: underline;
+  line-height: 2rem;
+  text-underline-offset: 4px;
 }
 
 li.document h3 a:hover {
   color: var(--orange-50, 10%);
   text-decoration: underline;
+  line-height: 2rem;
+  text-underline-offset: 4px;
 }
 
 li.document {
@@ -205,7 +210,7 @@ li.document {
 
 li.document:not(:last-child) {
   padding-bottom: 20px;
-  border-bottom: 3px var(--orange-50) solid;
+  border-bottom: solid 3px var(--gray-50);
 }
 
 .metadata {

--- a/src/components/TrayContainer.vue
+++ b/src/components/TrayContainer.vue
@@ -12,19 +12,17 @@
       </BestBetsTray>
     </div>
     <div class="tray-grid">
-      <div v-for="row in rows" :key="row[0]" class="row">
-        <template v-for="scope in row" :key="scope">
-          <SearchTray
-            v-if="scope"
-            :scope="scope"
-            :results-promise="searchService.results(scope, query)"
-          >
-          </SearchTray>
-          <div v-else class="placeholder">
-            <!-- no tray is configured for this cell -->
-          </div>
-        </template>
-      </div>
+      <template v-for="scope in traysToLink" :key="scope">
+        <SearchTray
+          v-if="scope"
+          :scope="scope"
+          :results-promise="searchService.results(scope, query)"
+        >
+        </SearchTray>
+        <div v-else class="placeholder">
+          <!-- no tray is configured for this cell -->
+        </div>
+      </template>
     </div>
   </div>
   <div v-else>
@@ -33,13 +31,11 @@
 </template>
 
 <script setup lang="ts">
-import { SearchScope } from '../enums/SearchScope';
 import { SearchService } from '../services/SearchService';
 import { SearchTermService } from '../services/SearchTermService';
 import SearchTray from './SearchTray.vue';
 import SearchBar from './SearchBar.vue';
 import InitialSearch from './InitialSearch.vue';
-import { Ref, ref } from 'vue';
 import { TrayOrder } from '../models/TrayOrder';
 import JumpToSection from './JumpToSection.vue';
 import BestBetsTray from './BestBetsTray.vue';
@@ -47,16 +43,14 @@ import BestBetsTray from './BestBetsTray.vue';
 const query = SearchTermService.term();
 const searchService = new SearchService();
 const traysToLink = new TrayOrder().asFlatArray();
-
-const trayOrder = new TrayOrder();
-const rows: Ref<SearchScope[][]> = ref(trayOrder.asRows);
 </script>
 
 <style>
 .tray-grid {
   display: flex;
   justify-content: center;
-  flex-wrap: wrap;
+  flex-flow: row wrap;
+  gap: 2rem;
 }
 
 .best-bets {
@@ -64,22 +58,21 @@ const rows: Ref<SearchScope[][]> = ref(trayOrder.asRows);
   margin-right: 15px;
 }
 
-.row {
-  margin-top: 30px;
-  display: flex;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  align-items: flex-start;
-  min-height: 300px;
-  width: 96vw;
-  gap: 2vw;
-}
+@media (min-width: 1281px) and (max-width: 2089px) {
+  section:nth-child(-n + 2) {
+    flex: 1 0 48%;
+  }
 
-.row > section,
-.row > div.placeholder {
-  width: max(calc(30vw - 30px), 360px);
-  overflow-wrap: anywhere;
-  flex-grow: 1;
+  section:not(:nth-child(-n + 2)):not(:nth-last-child(-n + 6)) {
+    background-color: #efefef;
+    border: none;
+    flex: 1 0 45%;
+    max-width: 45rem;
+  }
+
+  section:nth-last-child(-n + 6) {
+    flex: 1 0 30%;
+  }
 }
 
 .header__secondary {

--- a/src/components/TrayContainer.vue
+++ b/src/components/TrayContainer.vue
@@ -47,6 +47,7 @@ const traysToLink = new TrayOrder().asFlatArray();
 
 <style>
 .tray-grid {
+  padding: 10px;
   display: flex;
   justify-content: center;
   flex-flow: row wrap;
@@ -59,18 +60,18 @@ const traysToLink = new TrayOrder().asFlatArray();
 }
 
 @media (min-width: 1281px) and (max-width: 2089px) {
-  section:nth-child(-n + 2) {
+  .tray-grid section:nth-child(-n + 2) {
     flex: 1 0 48%;
   }
 
-  section:not(:nth-child(-n + 2)):not(:nth-last-child(-n + 6)) {
+  .tray-grid section:not(:nth-child(-n + 2)):not(:nth-last-child(-n + 6)) {
     background-color: #efefef;
     border: none;
     flex: 1 0 45%;
     max-width: 45rem;
   }
 
-  section:nth-last-child(-n + 6) {
+  .tray-grid section:nth-last-child(-n + 6) {
     flex: 1 0 30%;
   }
 }

--- a/src/components/TrayLayout.vue
+++ b/src/components/TrayLayout.vue
@@ -22,6 +22,5 @@ section {
   border: 2px var(--gray-90) solid;
   margin-top: 10px;
   min-height: 300px;
-  box-shadow: 3px 3px 0 0 var(--gray-90);
 }
 </style>

--- a/src/components/TrayLayout.vue
+++ b/src/components/TrayLayout.vue
@@ -16,7 +16,7 @@ const props = defineProps({
 });
 </script>
 <style>
-section {
+.tray-grid section {
   background-color: var(--white);
   padding: 2px 15px 18px;
   border: 2px var(--gray-90) solid;

--- a/src/components/TrayTitle.vue
+++ b/src/components/TrayTitle.vue
@@ -29,6 +29,6 @@ h3 a {
 }
 .description {
   padding: 3px 0 8px;
-  border-bottom: solid 2px var(--gray-50);
+  border-bottom: solid 3px var(--orange-50);
 }
 </style>


### PR DESCRIPTION
closes #257

supports screens:  (min-width: 1281px) and (max-width: 2089px)

Update tray grid to use flex and not arrays per column/row
screens: @media (min-width: 1281px) and (max-width: 2089px)
Remove shadow from tray; Increase line-height in titles for better readability;
Update refine results link to look like a link with bold font;
Underline main tray title description with orange-50;
Use gray to devide list of books in a tray;
Add light gray background color in middle trays;
Update color in best-bets; Add padding in best bets and tray-grid
