### PR TITLE
Remove margin from skip-to-content-links.

### DIFF
--- a/assets/app.css
+++ b/assets/app.css
@@ -12,6 +12,7 @@ body {
   font-size: 1.125rem;
   padding: 0;
   border: 0;
+  margin: 0;
 }
 
 .icon {

--- a/src/App.vue
+++ b/src/App.vue
@@ -86,5 +86,6 @@ a:focus {
 
 .skip-to-content-links {
   list-style-type: none;
+  margin: 0;
 }
 </style>


### PR DESCRIPTION
Add left and right margin in page-wrap class.

It was causing extra whitespace around the header and the footer.