### PR TITLE
Make Skip to Content visible on top of the lux header

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -71,12 +71,13 @@ a:focus {
 
 .skip-to-content-link {
   white-space: nowrap;
-  margin: 1em auto;
+  margin: 1px auto;
   top: 0;
   position: fixed;
   left: 50%;
   margin-left: -72px;
   opacity: 0;
+  z-index: 1000;
 }
 
 .skip-to-content-link:focus {


### PR DESCRIPTION
#351 started to use the header component from lux, but unfortunately, this also caused the Skip to Main link to be hidden behind the header.

This places the Skip to Main link over the Header when active, and makes the position consistent with what it was prior to #351.

Helps with #316 