### PR TITLE
[#316] use a consistent amount of spacing on the left

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -41,8 +41,8 @@ if (query) {
   flex-direction: column;
   min-height: 100vh;
   align-items: center;
-  margin-left: 8px;
-  margin-right: 8px;
+  margin-left: 1rem;
+  margin-right: 1rem;
 }
 
 .main {


### PR DESCRIPTION
This makes the left spacing consistent with the lux header and footer (which both have a padding of `1rem`, allowing the trays and logos to be aligned horizontally with each other.

helps with #316 