### PR TITLE
Bump lux version to 5.2.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@honeybadger-io/vue": "^6.1.7",
     "axios": "^1.5.1",
     "class-transformer": "^0.5.1",
-    "lux-design-system": "^5.2.12",
+    "lux-design-system": "^5.2.13",
     "typescript-eslint": "^7.8.0",
     "vue": "^3.3.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1716,10 +1716,10 @@ lru-cache@^10.2.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.2.2.tgz#48206bc114c1252940c41b25b41af5b545aca878"
   integrity sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==
 
-lux-design-system@^5.2.12:
-  version "5.2.12"
-  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.2.12.tgz#8253d8f2898e474d9d71b6b07fb937d1ee5043be"
-  integrity sha512-XwTNuGq8o2lSkllIOPgVcFkRe9Q2/bs4BrglrwJ0yuhBrk6mLy5ijuLgADbjurfAbRJCG3xQ+XmhI6tAV9ubDg==
+lux-design-system@^5.2.13:
+  version "5.2.13"
+  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.2.13.tgz#df28f8fe6333f2f16e874a0b70492bf743f65161"
+  integrity sha512-bcrQGeF756u6j8h0uPNbG59QNbsM8U8bs4UHbXTVqst/TTRumrDAd208UTWJsIcG1wGqtGO6kmw0rwlapM+eNw==
   dependencies:
     core-js "^3.8.3"
     register-service-worker "^1.7.2"


### PR DESCRIPTION
closes #316 , since this version of Lux has the same spacing in the header and footer.