### PR TITLE
[#380] Add library_title. Remove office, building and phone number

### DIFF
--- a/src/components/metadata/LibraryStaffMetadata.test.ts
+++ b/src/components/metadata/LibraryStaffMetadata.test.ts
@@ -15,13 +15,7 @@ describe('LibraryStaffMetadata', () => {
   it('includes the email', () => {
     expect(wrapper.text()).toContain('nibmus@princeton.edu');
   });
-  it('includes the phone', () => {
-    expect(wrapper.text()).toContain('(555) 111-1111');
-  });
-  it('includes the office number', () => {
-    expect(wrapper.text()).toContain('A-200');
-  });
-  it('includes the building location', () => {
-    expect(wrapper.text()).toContain('Firestone Library');
+  it('includes the library title of the library staff location', () => {
+    expect(wrapper.text()).toContain('Nap Coordinator');
   });
 });

--- a/src/components/metadata/LibraryStaffMetadata.vue
+++ b/src/components/metadata/LibraryStaffMetadata.vue
@@ -1,19 +1,11 @@
 <template>
+  <li v-if="document?.other_fields?.library_title">
+    <span class="visually-hidden">Library Title: </span
+    >{{ document.other_fields.library_title }}
+  </li>
   <li v-if="document?.other_fields?.email">
     <span class="visually-hidden">Email: </span
     >{{ document.other_fields.email }}
-  </li>
-  <li v-if="document?.other_fields?.phone">
-    <span class="visually-hidden">Phone: </span
-    >{{ document.other_fields.phone }}
-  </li>
-  <li v-if="document?.other_fields?.office">
-    <span class="visually-hidden">Office: </span
-    >{{ document.other_fields.office }}
-  </li>
-  <li v-if="document?.other_fields?.building">
-    <span class="visually-hidden">Building: </span
-    >{{ document.other_fields.building }}
   </li>
 </template>
 


### PR DESCRIPTION
closes #380 

The tray contains Staff member's name, library title and email.
Remove office, building and phone number