### PR TITLE
[#407] Add padding in the searchbar

### DIFF
--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -71,6 +71,9 @@ button {
   }
 }
 
+#search {
+  padding: 0.375rem 0.75rem;
+}
 .align-searchbar {
   display: flex;
   height: 60px;


### PR DESCRIPTION
closes #407 

I used the padding values from the catalog searchbar

![Screenshot of the searchbar](https://github.com/user-attachments/assets/3197c617-6604-4910-93ab-bde178e2fe46)
