### PR TITLE
Reduce spacing

### DIFF
--- a/src/components/SearchTray.vue
+++ b/src/components/SearchTray.vue
@@ -216,19 +216,18 @@ li.document h3 a:hover {
 }
 
 li.document {
-  padding-left: 1em;
-  padding-top: 34px;
+  padding: 0.5rem 0rem 0rem 0.5rem;
 }
 
 li.document:not(:last-child) {
-  padding-bottom: 20px;
-  border-bottom: solid 3px var(--gray-50);
+  padding-bottom: 0.5rem;
+  border-bottom: solid 1px var(--gray-50);
 }
 
 .metadata {
   list-style-type: none;
   padding: 0;
-  margin: 10px 0;
+  margin: 0.65rem 0 0 0;
 }
 
 .metadata li {

--- a/src/components/TrayTitle.vue
+++ b/src/components/TrayTitle.vue
@@ -38,6 +38,6 @@ const headingId = IdService.createDomId(props.heading);
 
 .description {
   padding: 3px 0 8px;
-  border-bottom: solid 3px var(--orange-50);
+  border-bottom: solid 2px var(--orange-50);
 }
 </style>


### PR DESCRIPTION
[SearchTray] li.document: reduce padding;
[SearchTray] li.document besides last child: Change padding; border-bottom and thickness [SearchTray] Metadata: change top margin; remove bottom margin; [TrayTitle] Reduce thickness of border-bottom

## ul.medata spacing
### before
![ul metadata spacing before](https://github.com/user-attachments/assets/8d0cf44e-43cf-4f64-a14c-45fc09b338f0)

### after
![ul metadata spacing after](https://github.com/user-attachments/assets/2d2435c4-3df3-4480-a6e2-3977ce4a06d8)


## li.document spacing

### before
![li.document spacing before](https://github.com/user-attachments/assets/3c462bd2-25c2-4afc-b8bd-c76ebf15e18e)

### after
![li.document spacing after](https://github.com/user-attachments/assets/0228fa84-59e2-4648-be42-0f84cd1f2dd9)

## li document bottom border 

### before
![li document bottom border before](https://github.com/user-attachments/assets/13b0d0a3-86b4-43d9-80ae-8613c15b48cd)


### after
![li document las child bottom border after](https://github.com/user-attachments/assets/1ecac38a-4542-47ec-894e-12b0208d1ef6)



## Tray title bottom border


### before
![Tray title bottom border before](https://github.com/user-attachments/assets/6fb0f74c-bb0d-47f2-aedf-2245c929aab9)


### after
![Tray title bottom border after](https://github.com/user-attachments/assets/7b54e300-d968-49e8-b084-489d071c5e59)


