### PR TITLE
Remove hard-coded psb-prod URLs

### DIFF
--- a/src/components/AppHeader.test.ts
+++ b/src/components/AppHeader.test.ts
@@ -7,19 +7,19 @@ const wrapper = mount(AppHeader);
 describe('AppHeader component', () => {
   test('it has a link to Accounts', () => {
     const accountsLink = wrapper.get(
-      'a[href="https://library.psb-prod.princeton.edu/services/accounts"]'
+      'a[href="https://library.princeton.edu/services/accounts"]'
     );
     expect(accountsLink.text()).toEqual('Accounts');
   });
   test('it has a link to Hours', () => {
     const hoursLink = wrapper.get(
-      'a[href="https://library.psb-prod.princeton.edu/hours"]'
+      'a[href="https://library.princeton.edu/hours"]'
     );
     expect(hoursLink.text()).toEqual('Hours');
   });
   test('it has a link to Hours', () => {
     const helpLink = wrapper.get(
-      'a[href="https://library.psb-prod.princeton.edu/hours"]'
+      'a[href="https://library.princeton.edu/hours"]'
     );
     expect(helpLink.text()).toEqual('Hours');
   });
@@ -55,7 +55,7 @@ describe('AppHeader component', () => {
     expect(digitalLibraryLink.text()).toEqual('Digital Library (DPUL)');
 
     const allSearchToolsLink = wrapper.get(
-      'a[href="https://library.psb-prod.princeton.edu/services?type=1551"]'
+      'a[href="https://library.princeton.edu/services?type=1551"]'
     );
     expect(allSearchToolsLink.text()).toEqual('All Search Tools');
   });

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -10,17 +10,17 @@ const menu_items = [
   {
     name: 'Accounts',
     component: 'Accounts',
-    href: 'https://library.psb-prod.princeton.edu/services/accounts'
+    href: 'https://library.princeton.edu/services/accounts'
   },
   {
     name: 'Hours',
     component: 'Hours',
-    href: 'https://library.psb-prod.princeton.edu/hours'
+    href: 'https://library.princeton.edu/hours'
   },
   {
     name: 'Help',
     component: 'Help',
-    href: 'https://library.psb-prod.princeton.edu/services/research-support/askus-chat-and-email'
+    href: 'https://library.princeton.edu/services/research-support/askus-chat-and-email'
   },
   {
     name: 'Search Tools',
@@ -54,7 +54,7 @@ const menu_items = [
       {
         name: 'All Search Tools',
         component: 'All Search Tools',
-        href: 'https://library.psb-prod.princeton.edu/services?type=1551'
+        href: 'https://library.princeton.edu/services?type=1551'
       }
     ]
   }

--- a/src/config/ScopeUrlMap.ts
+++ b/src/config/ScopeUrlMap.ts
@@ -10,5 +10,5 @@ export default {
   libguides: 'https://libguides.princeton.edu',
   pulmap: 'https://maps.princeton.edu',
   staff: 'https://library.princeton.edu/staff/directory',
-  website: 'https://library.psb-prod.princeton.edu/search'
+  website: 'https://library.princeton.edu/search'
 };


### PR DESCRIPTION
As part of the website migration, the new WDS-managed website will stop being at library.psb-prod.princeton.edu and instead be at library.princeton.edu.

Most of these changes can be made in the API using the feature flipper (see https://github.com/pulibrary/allsearch_api?tab=readme-ov-file#use-the-permanent-website-url), but the header and the zero-results tray had the
temporary psb-prod url hard-coded.