### PR TITLE
[#417] Display pronouns if available from the API

### DIFF
--- a/src/components/metadata/LibraryStaffMetadata.test.ts
+++ b/src/components/metadata/LibraryStaffMetadata.test.ts
@@ -18,4 +18,29 @@ describe('LibraryStaffMetadata', () => {
   it('includes the library title of the library staff location', () => {
     expect(wrapper.text()).toContain('Nap Coordinator');
   });
+  describe('when the staff member has added pronouns to their profile', () => {
+    beforeEach(() => {
+      wrapper = mount(LibraryStaffMetadata, {
+        props: {
+          document: LibraryStaffResultsFixtures.testResult2
+        }
+      });
+    });
+    it('includes the pronouns', () => {
+      expect(wrapper.text()).toContain('(he/they)');
+    });
+  });
+  describe('when the staff member has added pronouns with parentheses already included', () => {
+    beforeEach(() => {
+      wrapper = mount(LibraryStaffMetadata, {
+        props: {
+          document: LibraryStaffResultsFixtures.testResult3
+        }
+      });
+    });
+    it('includes the pronouns in just one set of parentheses', () => {
+      expect(wrapper.text()).toContain('(she/her/ella)');
+      expect(wrapper.text()).not.toContain('((she/her/ella))');
+    });
+  });
 });

--- a/src/components/metadata/LibraryStaffMetadata.vue
+++ b/src/components/metadata/LibraryStaffMetadata.vue
@@ -3,6 +3,9 @@
     <span class="visually-hidden">Library Title: </span
     >{{ document.other_fields.library_title }}
   </li>
+  <li v-if="pronouns">
+    <span class="visually-hidden">Pronouns: </span>{{ pronouns }}
+  </li>
   <li v-if="document?.other_fields?.email">
     <span class="visually-hidden">Email: </span
     >{{ document.other_fields.email }}
@@ -10,13 +13,24 @@
 </template>
 
 <script setup lang="ts">
-import { PropType } from 'vue';
+import { PropType, computed } from 'vue';
 import { SearchResult } from '../../models/SearchResult';
 
-defineProps({
+const props = defineProps({
   document: {
     type: Object as PropType<SearchResult>,
     required: true
   }
+});
+const pronouns = computed(() => {
+  const pronounsFromProfile = props.document?.other_fields?.pronouns;
+  if (pronounsFromProfile) {
+    // Remove preceding and trailing parentheses, if they exist...
+    const withoutParentheses = pronounsFromProfile.replaceAll(/(^\(|\)$)/g, '');
+    // ...then add back parentheses so that all pronouns display with
+    // just one set of parentheses
+    return `(${withoutParentheses})`;
+  }
+  return null;
 });
 </script>

--- a/src/fixtures/LibraryStaffResultsFixtures.ts
+++ b/src/fixtures/LibraryStaffResultsFixtures.ts
@@ -18,5 +18,23 @@ export default {
       phone: '(555) 111-1111',
       netid: 'nimbuskt'
     }
+  }),
+  testResult2: SearchResult.fromObject({
+    title: 'Staff, Test',
+    id: 9,
+    type: 'Library Staff',
+    url: 'https://library.princeton.edu/about/staff-directory/test-staff',
+    other_fields: {
+      pronouns: 'he/they'
+    }
+  }),
+  testResult3: SearchResult.fromObject({
+    title: 'World, Hello',
+    id: 10,
+    type: 'Library Staff',
+    url: 'https://library.princeton.edu/about/staff-directory/hello-world',
+    other_fields: {
+      pronouns: '(she/her/ella)'
+    }
   })
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "useDefineForClassFields": true,
     "module": "ESNext",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2021", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
     "moduleResolution": "node",
     // "allowImportingTsExtensions": true,


### PR DESCRIPTION
Also, increase the lib version in tsconfig, so that we can use String.prototype.replaceAll()

They display underneath the job title, in parentheses (because I thought the parentheses looked nice).

closes #417