### PR TITLE
[#422] Color changes to support dark theme

### DIFF
--- a/assets/app.css
+++ b/assets/app.css
@@ -166,6 +166,9 @@ h3 {
   a {
     color: var(--gray-10)
   }
+  .lux-alert-info a {
+    color: var(--color-bleu-de-france-darker);
+  }
 }
 
 /* Mobile rules */

--- a/assets/app.css
+++ b/assets/app.css
@@ -13,6 +13,9 @@ body {
   padding: 0;
   border: 0;
   margin: 0;
+  @media (prefers-color-scheme: dark) {
+    background-color: var(--color-gray-100);
+  }
 }
 
 .icon {
@@ -161,7 +164,7 @@ h3 {
 /* Dark mode rules */
 @media (prefers-color-scheme: dark) {
   a {
-    color: var(--color-bleu-de-france-lighter);
+    color: var(--gray-10)
   }
 }
 

--- a/src/components/BestBetsTray.vue
+++ b/src/components/BestBetsTray.vue
@@ -63,7 +63,7 @@ populateResults();
 }
 @media (prefers-color-scheme: dark) {
   .best-bets > section {
-    background-color: var(--color-grayscale-darker);
+    background-color: var(--color-gray-100);
   }
 }
 </style>

--- a/src/components/BestBetsTray.vue
+++ b/src/components/BestBetsTray.vue
@@ -63,7 +63,7 @@ populateResults();
 }
 @media (prefers-color-scheme: dark) {
   .best-bets > section {
-    background-color: var(--color-gray-100);
+    background-color: var(--color-grayscale-darker);
   }
 }
 </style>

--- a/src/components/JumpToSection.vue
+++ b/src/components/JumpToSection.vue
@@ -76,27 +76,42 @@ function toggleButton() {
   justify-content: center;
   background-color: var(--color-grayscale-lighter);
 
-  &:hover {
-    color: var(--black);
-    background-color: var(--orange-50);
-    cursor: pointer;
-  }
   a {
     text-decoration: none;
     flex: 1 1 auto;
     text-align: center;
     padding: 0.5rem;
   }
-  a:link {
-    color: var(--black);
+
+  @media (prefers-color-scheme: dark) {
+    background-color: var(--color-grayscale);
+    a:link {
+      color: var(--color-grayscale-lighter);
+    }
+
+    a:visited {
+      color: var(--color-grayscale-lighter);
+    }
   }
 
-  a:visited {
-    color: var(--black);
+  &:hover {
+    /* color: var(--black); */
+    background-color: var(--orange-50);
+    cursor: pointer;
   }
 
-  a:hover {
-    color: var(--gray-90);
+  @media (prefers-color-scheme: light) {
+    a:link {
+      color: var(--black);
+    }
+
+    a:visited {
+      color: var(--black);
+    }
+
+    a:hover {
+      color: var(--gray-90);
+    }
   }
 
   @media (min-width: 1200px) {
@@ -105,10 +120,7 @@ function toggleButton() {
   @media (min-width: 1000px) and (max-width: 1199px) {
     flex: 1 0 20%;
   }
-
   @media (max-width: 999px) {
-    /* in this media query ideally we want to collapse
-     the skip to section under one div */
     flex: 1 0 100%;
   }
 }

--- a/src/components/JumpToSection.vue
+++ b/src/components/JumpToSection.vue
@@ -74,7 +74,7 @@ function toggleButton() {
   list-style: none;
   display: inline-flex;
   justify-content: center;
-  background-color: #f5f4f1;
+  background-color: var(--color-grayscale-lighter);
 
   &:hover {
     color: var(--black);

--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -53,7 +53,8 @@ input {
   font-size: 1rem;
   flex: 1;
   @media (prefers-color-scheme: dark) {
-    border: 2px solid var(--color-white);
+    background-color: var(--color-grayscale-lighter);
+    color: var(--color-gray-100);
   }
 }
 

--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -49,12 +49,12 @@ const searchIsEmpty = () => {
 </script>
 <style scoped>
 input {
-  border: 2px solid var(--black);
+  border: 2px solid var(--gray-100);
   font-size: 1rem;
   flex: 1;
   @media (prefers-color-scheme: dark) {
-    background-color: var(--color-grayscale-lighter);
-    color: var(--color-gray-100);
+    background-color: var(--color-grayscale-darker);
+    color: var(--color-grayscale-lighter);
   }
 }
 
@@ -67,8 +67,9 @@ button {
   margin-left: 0;
   width: 51px;
   @media (prefers-color-scheme: dark) {
-    border: 2px solid var(--color-white);
-    border-left-width: 0;
+    border-left: 2px var(--gray-90) solid;
+    background-color: var(--color-grayscale-darker);
+    /* border-left-width: 0; */
   }
 }
 

--- a/src/components/TrayLayout.vue
+++ b/src/components/TrayLayout.vue
@@ -31,8 +31,8 @@ const props = defineProps({
 
 @media (prefers-color-scheme: dark) {
   .tray-grid section {
-    background-color: var(--black);
-    border: 2px var(--gray-10) solid;
+    background-color: var(--color-grayscale-dark);
+    /* border: 2px var(--gray-10) solid; */
   }
 }
 </style>

--- a/src/components/TrayLayout.vue
+++ b/src/components/TrayLayout.vue
@@ -31,8 +31,7 @@ const props = defineProps({
 
 @media (prefers-color-scheme: dark) {
   .tray-grid section {
-    background-color: var(--color-grayscale-dark);
-    /* border: 2px var(--gray-10) solid; */
+    background-color: var(--color-grayscale-darker);
   }
 }
 </style>

--- a/src/components/TrayTitle.vue
+++ b/src/components/TrayTitle.vue
@@ -32,7 +32,7 @@ const headingId = IdService.createDomId(props.heading);
 
 @media (prefers-color-scheme: dark) {
   h3 a {
-    color: var(--white);
+    color: var(--gray-10);
   }
 }
 


### PR DESCRIPTION
closes #422

Dark theme: Change the primary surface color to dark grey.
see material docs: https://m2.material.io/design/color/dark-theme.html#properties Remove tray border and support higher surface elevation for main tray components by providing a lighter shade of gray.
Change link color to light grey to support color contrast accessibility ratio.