### PR TITLE
Don't error when a user's browser has no window.localStorage

### DIFF
--- a/src/components/BannerAlert.vue
+++ b/src/components/BannerAlert.vue
@@ -25,7 +25,7 @@ async function populateResult(): Promise<void> {
 }
 
 function handleDismissed() {
-  window.localStorage.setItem(
+  window.localStorage?.setItem(
     'allsearch-banner-dismissed',
     JSON.stringify({
       date: new Date().toISOString().split('T')[0],
@@ -38,7 +38,7 @@ function shouldDisplayBanner(): boolean {
   if (!result.value) {
     return false;
   }
-  const lastDismissed = window.localStorage.getItem(
+  const lastDismissed = window.localStorage?.getItem(
     'allsearch-banner-dismissed'
   );
   if (lastDismissed) {


### PR DESCRIPTION
Resolves https://app.honeybadger.io/projects/114647/faults/111417888/01J7D78P0PDEMSA2XTX0FG5SRA -- where a user tried to dismiss the banner, but their browser had no window.localStorage to store that choice.