### PR TITLE
Rename bibdata-staging.princeton.edu to bibdata-staging.lib.princeton.edu

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
         default-src 'none'; 
         style-src 'self' 'unsafe-inline' https://use.typekit.net https://p.typekit.net;
         script-src 'self' https://www.googletagmanager.com/gtm.js 'unsafe-eval'; 
-        connect-src 'self' localhost:* https://allsearch-api.princeton.edu https://allsearch-api-staging.princeton.edu https://bibdata.princeton.edu https://bibdata-staging.princeton.edu https://api.honeybadger.io https://www.google-analytics.com; 
+        connect-src 'self' localhost:* https://allsearch-api.princeton.edu https://allsearch-api-staging.princeton.edu https://bibdata.princeton.edu https://bibdata-staging.lib.princeton.edu https://api.honeybadger.io https://www.google-analytics.com; 
         font-src 'self' https://use.typekit.net; 
         base-uri 'none';
         img-src 'self' data:" />

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,8 @@ export default {
     import.meta.env.VITE_ALLSEARCH_API_URL ||
     'https://allsearch-api-staging.princeton.edu',
   bibdataUrl:
-    import.meta.env.VITE_BIBDATA_URL || 'https://bibdata-staging.princeton.edu',
+    import.meta.env.VITE_BIBDATA_URL ||
+    'https://bibdata-staging.lib.princeton.edu',
   honeybadgerApiKey: import.meta.env.VITE_HONEYBADGER_API_KEY,
   honeybadgerEnvironment: import.meta.env.VITE_HONEYBADGER_ENV
 };


### PR DESCRIPTION
Rename bibdata-staging.princeton.edu to bibdata-staging.lib.princeton.edu
Bibdata staging is on adc-dev and using the .lib