### PR TITLE
Configure vite to output sourcemaps

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,5 +6,8 @@ export default defineConfig({
   plugins: [vue()],
   server: {
     cors: false
+  },
+  build: {
+    sourcemap: true
   }
 });


### PR DESCRIPTION
Helps with #444

One way you can validate this change:
1. `yarn build`
2. `cd dist && ruby -run -e httpd . -p 7878`
3. In firefox, go to http://localhost:7878/
4. Open the dev tools
5. Go to the sources tab
6. Note that in Main Thread > localhost:7878, there is a single assets/index* js file that is minified.
7. Check out this branch and repeat steps 1-5.
8. Note that in Main Thread > localhost:7878, we can still access the minified js file in assets, but we also have the original typescript available in src.