### PR TITLE
Remove dastardly from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,36 +55,6 @@ jobs:
       - node/install-packages:
           pkg-manager: yarn
       - ruby/rspec-test
-  dastardly:
-    machine:
-      image: ubuntu-2204:current
-    resource_class: medium # default is large, which is not needed for this job
-    steps:
-      - checkout
-      - node/install:
-          install-yarn: true
-          node-version: '23.11.0'
-      - node/install-packages:
-          pkg-manager: yarn
-      - run:
-          command: yarn global add wait-on
-      - run:
-          command: yarn dev
-          background: true
-          environment:
-            # Consult the production API, since the staging one is
-            # only available to the Princeton network
-            VITE_ALLSEARCH_API_URL: https://allsearch-api.princeton.edu
-      - run:
-          command: wait-on http://localhost:5173
-      - run: |
-          docker run --user $(id -u) --rm -v $(pwd):/dastardly \
-          --network="host" -e \
-          BURP_START_URL=http://127.0.0.1:5173 -e \
-          BURP_REPORT_FILE_PATH=/dastardly/dastardly-report.xml \
-          public.ecr.aws/portswigger/dastardly:latest
-      - store_test_results:
-          path: dastardly-report.xml
 
   bearer:
     docker:
@@ -104,5 +74,4 @@ workflows:
       - lint
       - semgrep
       - integration-tests
-      - dastardly
       - bearer


### PR DESCRIPTION
It is slow, and doesn't really catch any security issues