### PR TITLE
Separate JumpToSectionOrder from TrayOrder

### DIFF
--- a/src/components/JumpToSection.test.ts
+++ b/src/components/JumpToSection.test.ts
@@ -7,7 +7,7 @@ describe('JumpToSection component', () => {
   it('prints a link for each trayToLink', () => {
     const wrapper = mount(JumpToSectionComponent, {
       props: {
-        traysToLink: [
+        traysToJumpTo: [
           SearchScope.Catalog,
           SearchScope.Articles,
           SearchScope.FindingAids

--- a/src/components/JumpToSection.vue
+++ b/src/components/JumpToSection.vue
@@ -9,7 +9,7 @@
   >
   <div id="jump-to-section" class="display-none" tabindex="-1">
     <ul>
-      <template v-for="scope in props.traysToLink" :key="scope">
+      <template v-for="scope in props.traysToJumpTo" :key="scope">
         <li class="ul-border">
           <a :href="getHref(scope)">{{ ScopeTitleMap[scope] }}</a>
         </li>
@@ -24,7 +24,7 @@ import { SearchScope } from '../enums/SearchScope';
 import { IdService } from '../services/IdService';
 import { LuxInputButton } from 'lux-design-system';
 const props = defineProps({
-  traysToLink: {
+  traysToJumpTo: {
     type: Array as PropType<SearchScope[]>,
     required: true
   }

--- a/src/components/TrayContainer.vue
+++ b/src/components/TrayContainer.vue
@@ -3,7 +3,7 @@
     <div class="header__secondary">
       <nav aria-label="search tools" class="search-tools">
         <SearchBar></SearchBar>
-        <JumpToSection :trays-to-link="traysToLink"></JumpToSection>
+        <JumpToSection :trays-to-jump-to="traysToJumpTo"></JumpToSection>
       </nav>
     </div>
     <h1 class="visually-hidden">Search results</h1>
@@ -37,12 +37,14 @@ import SearchTray from './SearchTray.vue';
 import SearchBar from './SearchBar.vue';
 import InitialSearch from './InitialSearch.vue';
 import { TrayOrder } from '../models/TrayOrder';
+import { JumpToSectionOrder } from '../models/JumpToSectionOrder';
 import JumpToSection from './JumpToSection.vue';
 import BestBetsTray from './BestBetsTray.vue';
 
 const query = SearchTermService.term();
 const searchService = new SearchService();
 const traysToLink = new TrayOrder().resultCompareArray();
+const traysToJumpTo = new JumpToSectionOrder().order;
 </script>
 
 <style>

--- a/src/models/JumpToSectionOrder.test.ts
+++ b/src/models/JumpToSectionOrder.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'vitest';
+import { JumpToSectionOrder } from './JumpToSectionOrder';
+import { SearchScope } from '../enums/SearchScope';
+
+describe('SkipLinkOrder', () => {
+  const skip_link_order = new JumpToSectionOrder();
+
+  describe('order', () => {
+    test('it includes subset of trays in order from left-to-right', () => {
+      expect(skip_link_order.order).toEqual([
+        SearchScope.Catalog,
+        SearchScope.Articles,
+        SearchScope.Journals,
+        SearchScope.LibraryDatabases,
+        SearchScope.FindingAids,
+        SearchScope.Dpul,
+        SearchScope.PulMap,
+        SearchScope.ArtMuseum
+      ]);
+    });
+  });
+});

--- a/src/models/JumpToSectionOrder.ts
+++ b/src/models/JumpToSectionOrder.ts
@@ -1,0 +1,17 @@
+import { SearchScope } from '../enums/SearchScope';
+
+export class JumpToSectionOrder {
+  order: SearchScope[];
+  constructor() {
+    this.order = [
+      SearchScope.Catalog,
+      SearchScope.Articles,
+      SearchScope.Journals,
+      SearchScope.LibraryDatabases,
+      SearchScope.FindingAids,
+      SearchScope.Dpul,
+      SearchScope.PulMap,
+      SearchScope.ArtMuseum
+    ];
+  }
+}


### PR DESCRIPTION
In order to have all of the trays continue to display with fewer jump to section links, we have to separate them.

Connected to #500