### PR TITLE
506 bottom gap padding

### DIFF
--- a/src/components/SearchTray.vue
+++ b/src/components/SearchTray.vue
@@ -205,7 +205,6 @@ li.document h3 a:hover {
 }
 
 li.document:not(:last-child) {
-  padding-bottom: 0.7rem;
   border-bottom: solid 1px var(--gray-50);
 }
 
@@ -229,6 +228,7 @@ li.document::marker {
 
 .tray-grid ol li.document {
   list-style-type: none;
+  padding-bottom: 23px;
 }
 
 .access-info ul {


### PR DESCRIPTION
* Tray document uses the gap from the flexbox
* Add bottom padding at the end of the tray document to match figma design

helps with #506