### PR TITLE
[TrayTitle] Rename description class

### DIFF
--- a/src/components/SearchTray.test.ts
+++ b/src/components/SearchTray.test.ts
@@ -41,7 +41,7 @@ describe('SearchTray component', () => {
     ]);
   });
   test('it displays the appropriate description from the config', async () => {
-    expect(wrapper.find('div[class="description"]').text()).toEqual(
+    expect(wrapper.find('div[class="tray-description"]').text()).toEqual(
       'Articles, eBooks, and other online sources'
     );
   });

--- a/src/components/TrayTitle.test.ts
+++ b/src/components/TrayTitle.test.ts
@@ -45,7 +45,7 @@ describe('TrayTitle component', () => {
         description: 'The best place to search'
       }
     });
-    expect(wrapper.find('div[class="description"]').text()).toEqual(
+    expect(wrapper.find('div[class="tray-description"]').text()).toEqual(
       'The best place to search'
     );
   });

--- a/src/components/TrayTitle.vue
+++ b/src/components/TrayTitle.vue
@@ -3,7 +3,7 @@
     <h2 :id="headingId">
       {{ props.heading }}
     </h2>
-    <div class="description">
+    <div class="tray-description">
       {{ props.description }}
     </div>
   </div>
@@ -35,7 +35,7 @@ h3 a {
   text-decoration: none;
 }
 
-.description {
+.tray-description {
   padding-bottom: 16px;
   border-bottom: solid 2px var(--orange-50);
 }


### PR DESCRIPTION
* Rename description class to tray-description.


In a previous commit we created a class dynamically from the field name so that we style specific field in the metadata. this created a 'description' class in the span. this is why we were seeing the orange underline in the metadata. 