### PR TITLE
[ArticleMetadata] Use LuxShowMore for long abstracts

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@honeybadger-io/vue": "^6.1.7",
     "axios": "^1.8.2",
     "class-transformer": "^0.5.1",
-    "lux-design-system": "^6.7.0",
+    "lux-design-system": "^6.8.1",
     "typescript-eslint": "^7.8.0",
     "vue": "^3.3.4"
   },

--- a/src/components/SearchTray.vue
+++ b/src/components/SearchTray.vue
@@ -20,7 +20,7 @@
             :icon="getIconType(document.type)"
           ></FormatWithIcon>
           <h3 :data-id="document.id">
-            <a :href="document.url">{{ document.title }}</a>
+            <a :href="document.url" :id="document.id">{{ document.title }}</a>
           </h3>
           <SearchMetadata
             :basic-field-list="props.basicFieldList"

--- a/src/components/metadata/ArticlesMetadata.test.ts
+++ b/src/components/metadata/ArticlesMetadata.test.ts
@@ -16,7 +16,9 @@ describe('ArticlesMetadata', () => {
   it('displays html in the abstract, rather than converting it into entities', async () => {
     wrapper.get('button').trigger('click');
     await nextTick();
-    expect(wrapper.text()).toContain('This abstract contains HTML');
+    expect(wrapper.text()).toContain(
+      'This abstract is really quite long and it contains various HTML elements'
+    );
     expect(wrapper.text()).not.toContain('<i>');
     expect(wrapper.text()).not.toContain('<strong>');
     expect(wrapper.findAll('i').length).toEqual(1);

--- a/src/components/metadata/ArticlesMetadata.vue
+++ b/src/components/metadata/ArticlesMetadata.vue
@@ -1,15 +1,17 @@
 <template>
   <li>
-    <LuxDisclosure
+    <LuxShowMore
       v-if="document.other_fields?.abstract"
-      content-id="123"
+      content-id="abstract-{{document.id}}"
+      :description-id="document.id"
       show-label="Show abstract"
       hide-label="Hide abstract"
+      :character-limit="characterLimit"
       width="100%"
       font-size="1.125rem"
       ><!-- nosemgrep javascript.vue.security.audit.xss.templates.avoid-v-html.avoid-v-html -->
       <span v-html="document.other_fields.abstract"></span
-    ></LuxDisclosure>
+    ></LuxShowMore>
   </li>
   <li v-if="document.other_fields?.fulltext_available">
     <InlineBadge color="blue">Full-text available</InlineBadge>
@@ -23,7 +25,7 @@ import { SearchResult } from '../../models/SearchResult';
 
 import ArticleCitation from '../ArticleCitation.vue';
 import InlineBadge from '../InlineBadge.vue';
-import { LuxDisclosure } from 'lux-design-system';
+import { LuxShowMore } from 'lux-design-system';
 
 defineProps({
   document: {
@@ -31,4 +33,6 @@ defineProps({
     required: true
   }
 });
+
+const characterLimit = 100;
 </script>

--- a/src/fixtures/ArticleResultsFixtures.ts
+++ b/src/fixtures/ArticleResultsFixtures.ts
@@ -53,7 +53,8 @@ export default {
     description: 'This abstract <i>contains</i> <strong>HTML</strong>',
     url: 'http://example.com',
     other_fields: {
-      abstract: 'This abstract <i>contains</i> <strong>HTML</strong>'
+      abstract:
+        'This abstract <u>is really quite</u> long and it <i>contains</i> <span>various</span> <strong>HTML</strong> elements throughout its lengthy, never-ending, excessive, totally boring text'
     }
   })
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1932,10 +1932,10 @@ lru-cache@^10.2.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
   integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
 
-lux-design-system@^6.7.0:
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-6.7.0.tgz#fe1b2ec912b5479dbea72471cac7f2530bacdd55"
-  integrity sha512-MmfNJIFdpfoITQg2kpMnobuNoLOqoOOZBtizovKBaG1smLcDaXeKH6ktWdkyQR8hqLlwqywT8ohb7RtTvDmh7Q==
+lux-design-system@^6.8.1:
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-6.8.1.tgz#6cea3a4ea6123cd65d3443f62e92edffd4f42a73"
+  integrity sha512-QhQucvQ644H1GfC5tI8uVZHxWcRwf0ljDm7+e6Txj4+p1NB1vCzuQ0kPAgwDICgYwnvByEwq94p2jaJbGLkFgg==
   dependencies:
     core-js "^3.8.3"
     register-service-worker "^1.7.2"
@@ -2425,6 +2425,7 @@ string-argv@^0.3.2:
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==


### PR DESCRIPTION
Abstracts longer than 100 characters are truncated, and we get a Show abstract link

Helps with #508