### PR TITLE
Consistent line height on search result titles across states

### DIFF
--- a/assets/app.css
+++ b/assets/app.css
@@ -206,4 +206,7 @@ a {
   --marquand: var(--red);
   --mudd: #F2A900;
   --stokes: #C24D01;
+
+
+  --result-title-line-height: 1.875rem;
 }

--- a/src/components/SearchTray.vue
+++ b/src/components/SearchTray.vue
@@ -210,7 +210,7 @@ li.document h3 {
 }
 
 li.document h3 a {
-  line-height: 1.875rem;
+  line-height: var(--result-title-line-height);
   font-size: 1.25rem;
   font-style: normal;
   letter-spacing: 0.01375rem;
@@ -218,14 +218,14 @@ li.document h3 a {
 
 li.document h3 a:focus {
   text-decoration: underline;
-  line-height: 2rem;
+  line-height: var(--result-title-line-height);
   text-underline-offset: 4px;
 }
 
 li.document h3 a:hover {
   color: var(--orange-50, 10%);
   text-decoration: underline;
-  line-height: 2rem;
+  line-height: var(--result-title-line-height);
   text-underline-offset: 4px;
 }
 


### PR DESCRIPTION
This prevents us from shifting the layout when tabbing or moving the mouse between titles