### PR TITLE
Fix color of focus indicator

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -67,8 +67,9 @@ a:focus {
     var(--color-princeton-orange-on-white),
     var(--color-princeton-orange-on-black)
   );
-  outline: solid 0.25rem;
-  outline-offset: none;
+  outline-style: solid;
+  outline-width: 0.25rem;
+  outline-offset: unset;
   box-shadow: none;
 }
 
@@ -128,7 +129,9 @@ main {
   }
   &#main-content:focus {
     box-sizing: border-box;
-    outline: var(--color-princeton-orange-on-white) solid 0.25rem;
+    outline-color: var(--color-princeton-orange-on-white);
+    outline-style: solid;
+    outline-width: 0.25rem;
     outline-offset: -0.25rem;
   }
 }

--- a/src/components/JumpToSection.vue
+++ b/src/components/JumpToSection.vue
@@ -75,7 +75,7 @@ function toggleButton() {
 #jump-to-section-expand {
   background-color: var(--gray-70);
   text-align: left;
-  width: inherit;
+  width: 100%;
   font-weight: 600;
   font-size: 14px;
   padding: 8px;
@@ -103,12 +103,13 @@ function toggleButton() {
   list-style: none;
   display: flex;
   justify-content: flex-start;
-
+  padding: 0 0 8px 8px;
   a {
     text-decoration: none;
     flex: 1 1 auto;
     padding: 0.5rem;
     color: var(--white);
+    border-radius: 12px;
   }
 
   a:hover {
@@ -136,7 +137,7 @@ function toggleButton() {
   padding: var(--space-base);
   color: var(--gray-50);
 
-  @media (--media-query-medium-max) {
+  @media (max-width: 899px) {
     display: none;
   }
 }


### PR DESCRIPTION
Apparently you can't mix the short-hand and long-hand versions of outline - if you have both apparently the shorthand takes precendence.