### PR TITLE
[ArticlesMetadata] Use LuxBadge for full text availability

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@honeybadger-io/vue": "^6.1.7",
     "axios": "^1.8.2",
     "class-transformer": "^0.5.1",
-    "lux-design-system": "^6.8.1",
+    "lux-design-system": "^6.8.2",
     "typescript-eslint": "^7.8.0",
     "vue": "^3.3.4"
   },

--- a/src/components/metadata/ArticlesMetadata.vue
+++ b/src/components/metadata/ArticlesMetadata.vue
@@ -13,10 +13,13 @@
       <span v-html="document.other_fields.abstract"></span
     ></LuxShowMore>
   </li>
-  <li v-if="document.other_fields?.fulltext_available">
-    <InlineBadge color="blue">Full-text available</InlineBadge>
-  </li>
   <ArticleCitation :fields="document.other_fields"></ArticleCitation>
+  <li
+    v-if="document.other_fields?.fulltext_available"
+    class="full-text-available"
+  >
+    <LuxBadge color="blue">Full-text available</LuxBadge>
+  </li>
 </template>
 
 <script setup lang="ts">
@@ -24,8 +27,7 @@ import { PropType } from 'vue';
 import { SearchResult } from '../../models/SearchResult';
 
 import ArticleCitation from '../ArticleCitation.vue';
-import InlineBadge from '../InlineBadge.vue';
-import { LuxShowMore } from 'lux-design-system';
+import { LuxBadge, LuxShowMore } from 'lux-design-system';
 
 defineProps({
   document: {
@@ -40,5 +42,8 @@ const characterLimit = 100;
 .lux-show-more button.lux-button {
   color: light-dark(var(--grey-100), var(--color-white));
   text-decoration-color: light-dark(var(--grey-100), var(--color-white));
+}
+.full-text-available .lux-badge {
+  text-transform: uppercase;
 }
 </style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1932,10 +1932,10 @@ lru-cache@^10.2.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
   integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
 
-lux-design-system@^6.8.1:
-  version "6.8.1"
-  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-6.8.1.tgz#6cea3a4ea6123cd65d3443f62e92edffd4f42a73"
-  integrity sha512-QhQucvQ644H1GfC5tI8uVZHxWcRwf0ljDm7+e6Txj4+p1NB1vCzuQ0kPAgwDICgYwnvByEwq94p2jaJbGLkFgg==
+lux-design-system@^6.8.2:
+  version "6.8.2"
+  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-6.8.2.tgz#0748176005e08c4e80095e5a18a4ce58eac77ea4"
+  integrity sha512-J3WG/S9asHDfHyJX7WVQQz8kx8kFTfkQm8EacAZaWWgfnAoa1odviVmQ0oDiBquvz9icQC+eKY0cQk/sKs2AnQ==
   dependencies:
     core-js "^3.8.3"
     register-service-worker "^1.7.2"


### PR DESCRIPTION
Helps with #508

Screenshot:
<img width="542" alt="article result, showing a rounded badge that says Full Text Available" src="https://github.com/user-attachments/assets/71cf6f61-6ea2-4c2c-b974-4acaa38c418b" />
