### PR TITLE
[JumpToSection] Horizontally align Jump to results button with its contents

### DIFF
--- a/src/components/JumpToSection.vue
+++ b/src/components/JumpToSection.vue
@@ -78,7 +78,7 @@ function toggleButton() {
   width: 100%;
   font-weight: 600;
   font-size: 14px;
-  padding: 8px;
+  padding: var(--space-x-small) var(--space-small);
   margin: 0px;
   border-radius: 12px;
   display: flex;
@@ -111,6 +111,10 @@ function toggleButton() {
     padding: 0.5rem;
     color: var(--gray-100);
     border-radius: 12px;
+
+    @media (max-width: 899px) {
+      padding: 0 0 var(--space-x-small) var(--space-x-small);
+    }
   }
 
   a:hover {


### PR DESCRIPTION
Jump to results is now in line with Catalog, Articles+, etc.

![screenshot of Jump to results, as described above](https://github.com/user-attachments/assets/a243e4a2-a25f-45b4-b0a6-8b7f463a89cb)



Closes #581