### PR TITLE
Allow local analytics implementation.

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
       content="
         default-src 'none'; 
         style-src 'self' 'unsafe-inline' https://use.typekit.net https://p.typekit.net https://tagmanager.google.com/ https://www.googletagmanager.com/;
-        script-src 'self' https://tagmanager.google.com/ https://www.googletagmanager.com/ 'unsafe-eval' 'unsafe-inline';         
+        script-src 'self' https://tagmanager.google.com/ https://www.googletagmanager.com/ https://analytics.lib.princeton.edu/ 'unsafe-eval' 'unsafe-inline';         
         connect-src 'self' localhost:* https://allsearch-api.princeton.edu https://allsearch-api-staging.princeton.edu https://bibdata.princeton.edu https://bibdata-staging.lib.princeton.edu https://api.honeybadger.io https://www.google-analytics.com; 
         font-src 'self' https://use.typekit.net; 
         base-uri 'none';


### PR DESCRIPTION
I added the tag for our local analytics with google tag manager, but CSP
(very nicely) blocked it.

Work towards pulibrary/dpul-collections#709