### PR TITLE
Address visual regression when banner is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,13 @@ The allsearch frontend depends on the [Library UX](https://github.com/pulibrary/
 1. `asdf install`
 1. `yarn install`
 1. `yarn dev`
-1. Note: In order to see search results you must be on the library VPN.
+
+By default, this shows production data.
+
+* If you want to see staging data instead, connect to the VPN and
+  run `VITE_ALLSEARCH_API_URL=https://allsearch-api-staging.princeton.edu yarn dev`
+* If you want to see data from the API running locally on port 3000,
+  run `VITE_ALLSEARCH_API_URL=http://localhost:3000 yarn dev`
 
 ## Vue 3 + TypeScript + Vite
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -39,15 +39,20 @@ const traysToJumpTo = new JumpToSectionOrder().order;
       <SearchBar></SearchBar>
       <JumpToSection :trays-to-jump-to="traysToJumpTo"></JumpToSection>
     </SearchTools>
-    <main id="main-content" class="search-results" tabindex="-1">
+    <main id="main-content" tabindex="-1">
       <div class="banner-wrapper">
         <BannerAlert></BannerAlert>
       </div>
-      <TrayContainer></TrayContainer>
+      <div class="search-results">
+        <TrayContainer></TrayContainer>
+      </div>
     </main>
   </template>
   <main id="main-content" v-else tabindex="-1">
     <InitialSearch></InitialSearch>
+    <div class="banner-wrapper">
+      <BannerAlert></BannerAlert>
+    </div>
   </main>
 
   <AppFooter></AppFooter>
@@ -123,12 +128,6 @@ a:focus {
 
 main {
   flex: 1;
-  &.search-results {
-    padding: var(--space-base) var(--space-x-large) var(--space-x-larger)
-      var(--space-x-large);
-    display: flex;
-    justify-content: center;
-  }
   &#main-content:focus {
     box-sizing: border-box;
     outline-color: var(--color-princeton-orange-on-white);

--- a/src/components/TrayContainer.vue
+++ b/src/components/TrayContainer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="query">
+  <div v-if="query" class="tray-container">
     <h1 class="visually-hidden">Search results</h1>
     <div class="best-bets">
       <BestBetsTray :results-promise="searchService.results('best-bet', query)">
@@ -79,5 +79,12 @@ const traysToLink = new TrayOrder().order;
 
 .header__secondary {
   position: relative;
+}
+
+.tray-container {
+  padding: var(--space-base) var(--space-x-large) var(--space-x-larger)
+    var(--space-x-large);
+  display: flex;
+  justify-content: center;
 }
 </style>


### PR DESCRIPTION
Here is what the fixed version looks like:
<img width="1376" height="571" alt="banner is immediately below the jump to section links" src="https://github.com/user-attachments/assets/43348639-4760-436d-a7f5-ab179192323e" />


Closes #633