### PR TITLE
[#638] Dark mode link color for lux alerts

### DIFF
--- a/assets/app.css
+++ b/assets/app.css
@@ -160,7 +160,7 @@ a {
   color: light-dark(var(--color-bleu-de-france), var(--gray-10));
 }
 
-.lux-alert-info a {
+.lux-alert a {
   color: light-dark(var(--color-cerulean-blue), var(--color-bleu-de-france-darker));
 }
 


### PR DESCRIPTION
Prior to this commit, we had specific color handling for dark mode on lux-alerts with status of info.  However, lux-alerts can also have a status of success, warning, or error.  Since no specific rule existed for these, the color fell back to the default link color of `var(--gray-10)`, which is not readable on any of those backgrounds.

Closes #638 