### PR TITLE
Fix light-dark handling when using lighting css

### DIFF
--- a/assets/app.css
+++ b/assets/app.css
@@ -14,6 +14,15 @@ body {
   border: 0;
   margin: 0;
   background-color: #EDEDED;
+  color-scheme: light dark;
+}
+
+body[data-theme=light] {
+  color-scheme: light;
+}
+
+body[data-theme=dark] {
+  color-scheme: dark;
 }
 
 .icon {

--- a/src/App.vue
+++ b/src/App.vue
@@ -14,6 +14,7 @@ const colorMode = localStorage.getItem('mode') || 'dark light';
 document
   .querySelector('meta[name="color-scheme"]')
   ?.setAttribute('content', colorMode);
+document.body.dataset.theme = colorMode;
 
 const query = SearchTermService.term();
 if (query) {

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -93,6 +93,7 @@ function switchMode(value: string) {
   window.localStorage.setItem('mode', value);
   const colorSchemeMeta = document.querySelector('meta[name="color-scheme"]');
   colorSchemeMeta?.setAttribute('content', value);
+  document.body.dataset.theme = value;
 }
 function handleMenuItemClicked(event: { component: keyof typeof colorModes }) {
   if (colorModes[event.component]) {


### PR DESCRIPTION
Vite 8 includes lightning CSS, which [takes a specific approach to handling the CSS light-dark rule](https://lightningcss.dev/transpilation.html#light-dark()-color-function)

We were missing a `color-scheme` rule on an ancestor element, leading to some messed up styles.

Before:
<img width="1095" height="623" alt="the search result trays do not have their own background color, they blend into the body background" src="https://github.com/user-attachments/assets/fdf1a138-1185-4c39-aeae-5d0055577cfd" />




After:
<img width="1197" height="660" alt="each tray has a white background which contrasts with the body background" src="https://github.com/user-attachments/assets/89d44e4a-7712-4832-8b1a-026d84da52e6" />